### PR TITLE
Add colorize gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,6 @@ group :test do
   gem 'simplecov', '~> 0.21'
 end
 
+gem 'colorize'
+
 gemspec

--- a/lib/uber_task/task_context.rb
+++ b/lib/uber_task/task_context.rb
@@ -128,7 +128,7 @@ module UberTask
     end
 
     def full_name
-      result = @scope.to_s.purple + ".#{@method}".cyan
+      result = @scope.to_s.magenta + ".#{@method}".cyan
       result += " #{@name.to_s.white}" unless @name.nil?
       result
     end

--- a/spec/rspec_settings.rb
+++ b/spec/rspec_settings.rb
@@ -7,7 +7,6 @@ end
 
 require 'uber_task'
 require 'colorize'
-require 'colorized_string'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|

--- a/spec/rspec_settings.rb
+++ b/spec/rspec_settings.rb
@@ -6,6 +6,8 @@ SimpleCov.start do
 end
 
 require 'uber_task'
+require 'colorize'
+require 'colorized_string'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|


### PR DESCRIPTION
### Context

While adding the specs for the `on_report` method, the following error was raised:
<img width="666" alt="spec error" src="https://github.com/shakacode/uber_task/assets/1019076/d6500a5c-f5a7-4bd8-9336-78db989de6d3">

We decided to add the [colorize](https://github.com/fazibear/colorize) gem.

**Note**
1. As per the [CHANGELOG](https://github.com/fazibear/colorize/blob/master/CHANGELOG.md#105--2023-06-22) `purple` was replaced by `magenta`. 
