### PR TITLE
Fix rubocop offenses

### DIFF
--- a/lib/uber_task.rb
+++ b/lib/uber_task.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'logger'
 require 'uber_task/internal'
 require 'uber_task/internal/path'

--- a/lib/uber_task/internal.rb
+++ b/lib/uber_task/internal.rb
@@ -3,10 +3,10 @@
 module UberTask
   module Internal
     def self.trace
-      if Thread.current[:__uber_task_trace__]
-        message = yield
-        puts message
-      end
+      return unless Thread.current[:__uber_task_trace__]
+
+      message = yield
+      puts message
     end
   end
 end

--- a/spec/exception_spec.rb
+++ b/spec/exception_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 describe UberTask do
   it 'Retries the child task after two exceptions' do
     task_retried_after_exception = 0
 
     UberTask.run do
-      UberTask.on_subtask_error do |task, event, err|
+      UberTask.on_subtask_error do |_task, _event, err|
         if err.message == 'Some error'
           task_retried_after_exception += 1
           UberTask.retry(reason: err, wait: 1)
@@ -16,7 +18,6 @@ describe UberTask do
         end
       end
     end
-
 
     expect(task_retried_after_exception).to be(2)
   end

--- a/spec/uber_task/run_spec.rb
+++ b/spec/uber_task/run_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 describe UberTask do
   describe '.run' do
     it 'retries the task' do
       run_count = 0
-      
+
       UberTask.run(retry_count: 3) do
         if run_count < 2
           run_count += 1

--- a/spec/uber_task/skip_spec.rb
+++ b/spec/uber_task/skip_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe UberTask do
   it 'skips the task' do
     task_skipped = true


### PR DESCRIPTION
**What does this PR do?**
This PR fixes rubocop offenses found by `bundle exec rubocop` task

**Note**
Seems that @pedrinlopes  uses Windows and because of that we get incorrect line endings, here is a [link](https://medium.com/@csmunuku/windows-and-linux-eol-sequence-configure-vs-code-and-git-37be98ef71df#:~:text=VS%20Code%20%3D%3E%20Settings%20%3D%3E,have%20Windows%20Style%20line%20endings.) describing how to change to Unix-like EoL (assuming @pedrinlopes uses VS Code)

<img width="1102" alt="Screenshot 2024-07-04 at 10 47 05" src="https://github.com/shakacode/uber_task/assets/32741269/ae1a00de-4e62-4054-a799-10ad981d5393">

**Rubocop**
```
bundle exec rubocop

30 files inspected, no offenses detected
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for tracing messages in the internal module for better code clarity.

- **Chores**
  - Added `# frozen_string_literal: true` directive to several files for enforcing immutable strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->