### PR TITLE
Add lefthook and configure it to check rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,13 @@
 source 'https://rubygems.org'
 
 group :development do
+  gem 'lefthook', '~> 1.6.18'
   gem 'rake', '~> 13.0'
+  gem 'rubocop', '~> 1.21'
 end
 
 group :test do
   gem 'rspec', '~> 3.2'
-  gem 'rubocop', '~> 1.21'
   gem 'simplecov', '~> 0.21'
 end
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-push:
+  commands:
+    rubocop: &rubocop
+      files: git diff --name-only --diff-filter=d $(git merge-base origin/main HEAD)..HEAD
+      glob: "*.{rb,rake}"
+      run: bundle exec rubocop --parallel --force-exclusion {files}
+
+pre-commit:
+  commands:
+    rubocop:
+      <<: *rubocop
+      files: git diff --name-only --diff-filter=d HEAD


### PR DESCRIPTION
**What does this PR do?**
This PR adds [lefthook](https://github.com/evilmartians/lefthook) and configures hook to check for rubocop offenses in `pre-push` and `pre-commit` hooks

**Note**
- `rubocop` gem is also moved from **test** to  **development** group because it's a linter
- I don't insist in using this `gem` but personally think it's a great tool to run simple hooks before commting or pushing new changes to repo. @borela WDYT?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated `lefthook` for enhanced pre-commit and pre-push hook management.
  
- **Chores**
  - Removed `rubocop` gem from the test group and updated its execution via `lefthook` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->