### PR TITLE
Add configurable logger usage

### DIFF
--- a/lib/uber_task.rb
+++ b/lib/uber_task.rb
@@ -13,6 +13,19 @@ require 'uber_task/skip_task'
 require 'uber_task/task_context'
 
 module UberTask
+  class << self
+    attr_writer :logger
+
+    def logger
+      @logger ||=
+        if defined?(Rails.logger)
+          Rails.logger
+        else
+          Logger.new($stdout, progname: name)
+        end
+    end
+  end
+
   def self.current
     Thread.current[:__uber_task_stack__] ||= []
     Thread.current[:__uber_task_stack__].last

--- a/lib/uber_task/internal.rb
+++ b/lib/uber_task/internal.rb
@@ -5,8 +5,7 @@ module UberTask
     def self.trace
       return unless Thread.current[:__uber_task_trace__]
 
-      message = yield
-      puts message
+      UberTask.logger.debug yield
     end
   end
 end

--- a/spec/uber_task/internal_spec.rb
+++ b/spec/uber_task/internal_spec.rb
@@ -35,10 +35,10 @@ describe UberTask::Internal do
         UberTask.enable_tracing
       end
 
-      it 'sends the trace message to puts' do
-        expect do
-          described_class.trace { 'some message' }
-        end.to output("some message\n").to_stdout
+      it 'logs the trace message via logger\'s debug level' do
+        expect(UberTask.logger).to receive(:debug).with('some message')
+
+        described_class.trace { 'some message' }
       end
     end
   end

--- a/spec/uber_task/logger_spec.rb
+++ b/spec/uber_task/logger_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe UberTask do
+  before do
+    described_class.instance_variable_set(:@logger, nil)
+  end
+
+  describe '.logger' do
+    it 'memoizes variable' do
+      initialized_logger = described_class.logger
+
+      expect(described_class.logger.object_id).to eq(
+        initialized_logger.object_id,
+      )
+    end
+
+    context 'when Rails logger is not defined' do
+      it 'uses stdout logger by default' do
+        expect do
+          described_class.logger.info('some message')
+        end.to output(/some message/).to_stdout
+      end
+    end
+  end
+
+  describe '.logger=' do
+    it 'changes logger' do
+      old_logger = described_class.logger
+      new_logger = Logger.new($stderr)
+
+      described_class.logger = new_logger
+
+      expect(described_class.logger).to eq(new_logger)
+      expect(described_class.logger).not_to eq(old_logger)
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
This PR adds usage of configurable `logger` which replaces `puts`. STDOUT logger is used by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic logger setup in the app, which defaults to `Rails.logger` or falls back to a custom logger if `Rails.logger` is unavailable.

- **Bug Fixes**
  - Updated trace message handling to use the logger's debug level, ensuring consistent logging behavior.

- **Tests**
  - Added tests for the new logger functionality to verify correct logger initialization and behavior.
  - Updated existing tests to reflect changes in trace message logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->