### PR TITLE
Validate UberTask::RetryTask's wait value

### DIFF
--- a/lib/uber_task/retry_task.rb
+++ b/lib/uber_task/retry_task.rb
@@ -7,10 +7,19 @@ module UberTask
     attr_accessor :reason,
                   :wait
 
-    def initialize(reason: nil, wait: nil)
+    def initialize(reason: nil, wait: 0)
+      validate_wait_value!(wait)
+
       super('Requested to retry the task.')
       @reason = reason
       @wait = wait
+    end
+
+    private
+
+    def validate_wait_value!(value)
+      raise ArgumentError, '`wait` is not numberic' unless value.is_a?(Numeric)
+      raise ArgumentError, '`wait` cannot be negative' if value.negative?
     end
   end
 end

--- a/spec/uber_task/retry_task_spec.rb
+++ b/spec/uber_task/retry_task_spec.rb
@@ -20,7 +20,25 @@ describe UberTask::RetryTask do
     expect(exception.wait).to eq(42)
   end
 
+  it 'has 0 as a default wait attribute value' do
+    expect(described_class.new.wait).to eq(0)
+  end
+
   it 'has a message' do
     expect(exception.message).to eq('Requested to retry the task.')
+  end
+
+  describe 'wait attribute validations' do
+    it 'does not allow non-numeric value' do
+      expect do
+        described_class.new(wait: 'string')
+      end.to raise_error(ArgumentError, '`wait` is not numberic')
+    end
+
+    it 'does not allow negative value' do
+      expect do
+        described_class.new(wait: -1)
+      end.to raise_error(ArgumentError, '`wait` cannot be negative')
+    end
   end
 end


### PR DESCRIPTION
### What does this PR do?

This PR:
1. Sets `0` (i/o `nil`) as default `wait` value for `UberTask::RetryTask`
2. Validates that `wait` value is numeric and positive

### Note

We need to validate value of `wait` attribute because we expect that value is `Numeric`. For example this will fail unexpectedly:
```
require 'uber_task'

UberTask.run("some task") do
  raise UberTask::RetryTask.new(reason: "some reason)
end
```

Backtrace:
```
lib/ruby/gems/3.2.0/gems/uber_task-0.1.0/lib/uber_task/task_context.rb:174:in `retry?': undefined method `positive?' for nil:NilClass (NoMethodError)

        if err.wait.positive?
	from lib/ruby/gems/3.2.0/gems/uber_task-0.1.0/lib/uber_task/task_context.rb:56:in `rescue in execute'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the `wait` value in retry tasks is numeric and non-negative, improving stability and reliability.

- **Tests**
  - Added tests for the default `wait` value and validation checks, enhancing test coverage for retry tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->