### PR TITLE
Add missing dependency to gemspec

### DIFF
--- a/lib/uber_task/task_context.rb
+++ b/lib/uber_task/task_context.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'colorize'
+
 module UberTask
   class TaskContext
     attr_reader :body,

--- a/uber_task.gemspec
+++ b/uber_task.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
   s.files = Dir['lib/**/*', 'LICENSE', 'README.md']
+
+  s.add_dependency('colorize', '~> 1.1.0')
 end


### PR DESCRIPTION
### What does this PR?

This PR adds `colorize` gem as runtime dependancy to gem specification

### Why?

`UberTask::TaskContext` colorizes messages - in `#exit_message` for example



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced task output with colorized text for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->