### PR TITLE
Improve release rake task and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,12 @@ lefthook install
 
 Releases are managed by project maintainers. See `rakelib/release.rake` for the release process.
 
+**Before releasing**, ensure the CHANGELOG.md is updated:
+1. Move items from "Unreleased" to a new version section
+2. Add the release date to the new version heading
+
 The release task handles:
-- Version bumping
+- Version bumping (via `gem-release`, included in dev dependencies)
 - Git tagging
 - Gem publishing to RubyGems
 
@@ -121,17 +125,17 @@ To create a release (maintainers only):
 
 ```bash
 # Bump patch version and release
-rake release[patch]
+bundle exec rake release[patch]
 
 # Bump minor version and release
-rake release[minor]
+bundle exec rake release[minor]
 
 # Bump major version and release
-rake release[major]
+bundle exec rake release[major]
 
 # Set explicit version and release
-rake release[0.2.0]
+bundle exec rake release[0.2.0]
 
 # Dry run (no actual release)
-rake release[patch,true]
+bundle exec rake release[patch,true]
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 group :development do
+  gem 'gem-release', '~> 2.2'
   gem 'lefthook', '~> 1.6.18'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.21'

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -3,7 +3,7 @@
 desc <<~DESC
   Release the gem with the given version.
 
-  This task depends on the gem-release gem which is installed via `gem install gem-release`.
+  This task depends on the gem-release gem (included in development dependencies).
 
   Arguments:
     version: Can be 'patch', 'minor', 'major', or an explicit version (e.g., '0.2.0' or '0.2.0.beta.1')
@@ -44,7 +44,7 @@ task :release, %i[version dry_run] do |_t, args|
 
       puts "Command failed (attempt #{retries}/#{max_retries}). Retrying..."
       if command.include?('gem push') || command.include?('gem release')
-        puts 'Enter new RubyGems OTP if needed:'
+        puts 'If this was an OTP issue, enter new RubyGems OTP:'
       end
     end
   end
@@ -67,24 +67,11 @@ task :release, %i[version dry_run] do |_t, args|
   log 'Pulling latest changes...', force: true
   sh_with_retry('git pull --rebase')
 
-  # Determine version bump type
-  bump_type = case version
-              when 'patch', 'minor', 'major'
-                version
-              end
-
   # Bump version using gem-release
   log 'Bumping gem version...', force: true
-  bump_command = if bump_type
-                   "gem bump --version #{bump_type} --no-commit"
-                 else
-                   "gem bump --version #{version} --no-commit"
-                 end
-  sh_with_retry(bump_command)
+  sh_with_retry("gem bump --version #{version} --no-commit")
 
-  # Get the new version
-  require_relative '../lib/uber_task/version'
-  # Force reload of version file
+  # Get the new version by loading the updated version file
   load File.join(gem_root, 'lib', 'uber_task', 'version.rb')
   new_version = UberTask::VERSION
 
@@ -124,7 +111,6 @@ task :release, %i[version dry_run] do |_t, args|
   log '=' * 80, force: true
   log '', force: true
   log 'Next steps:', force: true
-  log '  1. Update CHANGELOG.md with release notes', force: true
   github_url = 'https://github.com/shakacode/uber_task/releases/new'
-  log "  2. Create a GitHub release at #{github_url}", force: true
+  log "  1. Create a GitHub release at #{github_url}", force: true
 end


### PR DESCRIPTION
## Summary

- Add `gem-release` to Gemfile development dependencies (no longer requires manual `gem install`)
- Simplify version bump command logic (remove redundant case/if)
- Fix version constant loading (use only `load`, not `require_relative` followed by `load`)
- Improve OTP retry message to be clearer about when OTP might be needed
- Update CONTRIBUTING.md with proper release workflow (changelog before release)
- Add `bundle exec` prefix to release commands in documentation

## Test plan

- [x] RuboCop passes (42 files, no offenses)
- [x] RSpec passes (40 examples, 0 failures)
- [ ] Verify release task still works (dry run: `bundle exec rake release[patch,true]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised contributor release documentation with updated step-by-step instructions for executing releases and managing changelog updates.

* **Chores**
  * Added development dependency to standardize and enhance the release workflow.
  * Simplified release task implementation while improving authentication error messaging and user guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->